### PR TITLE
Add structured logging and custom roundtripper (#3)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,88 @@
 
 
 [[projects]]
+  digest = "1:63801c64679bdeef1b63206f065d5a1f4c3a75ed66a3fbbd909bf98766542980"
+  name = "github.com/labstack/echo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1abaa3049251d17932e4313c2d6165073fd07fd8"
+  version = "v3.3.6"
+
+[[projects]]
+  digest = "1:faee5b9f53eb1ae4eb04708c040c8c4dd685ce46509671e57a08520a15c54368"
+  name = "github.com/labstack/gommon"
+  packages = [
+    "color",
+    "log",
+  ]
+  pruneopts = "UT"
+  revision = "2a618302b929cc20862dda3aa6f02f64dbe740dd"
+  version = "v0.2.7"
+
+[[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
+
+[[projects]]
+  digest = "1:5bc8f93f977b72a7a5264725c3bab275e69de0cc3e5c0dc1ee56feb564c33f03"
+  name = "github.com/rs/zerolog"
+  packages = [
+    ".",
+    "internal/cbor",
+    "internal/json",
+  ]
+  pruneopts = "UT"
+  revision = "338f9bc14084d22cb8eeacd6492861f8449d715c"
+  version = "v1.9.1"
+
+[[projects]]
+  digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
+  name = "github.com/valyala/bytebufferpool"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:268b8bce0064e8c057d7b913605459f9a26dcab864c0886a56d196540fbf003f"
+  name = "github.com/valyala/fasttemplate"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "dcecefd839c4193db0d35b88ec65b4c12d360ab0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:dedf20eb0d3e8d6aa8a4d3d2fae248222b688ed528201995e152cc497899123c"
+  name = "golang.org/x/crypto"
+  packages = [
+    "acme",
+    "acme/autocert",
+  ]
+  pruneopts = "UT"
+  revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
+
+[[projects]]
+  branch = "master"
+  digest = "1:199248809ceaae02531db528e4e72d0d46eac33028bdf416ec5839bd8b35a1f7"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  pruneopts = "UT"
+  revision = "1561086e645b2809fb9f8a1e2a38160bf8d53bf4"
+
+[[projects]]
   digest = "1:43b8a34f6390d8fbdcfd300ed52103064e9eaaecc7e50b7e3518fe246ebe8403"
   name = "gopkg.in/tylerb/graceful.v1"
   packages = ["."]
@@ -12,6 +94,10 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = ["gopkg.in/tylerb/graceful.v1"]
+  input-imports = [
+    "github.com/labstack/echo",
+    "github.com/rs/zerolog",
+    "gopkg.in/tylerb/graceful.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/logger/log.go
+++ b/logger/log.go
@@ -1,0 +1,78 @@
+package logger
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo"
+	"github.com/rs/zerolog"
+)
+
+// HTTPLogger returns a custom logging middleware that uses zerolog
+func HTTPLogger(log *zerolog.Logger) echo.MiddlewareFunc {
+	return getLogger(log, false, func(log *zerolog.Logger, s string) string {
+		return s
+	})
+}
+
+func getLogger(log *zerolog.Logger, errorsOnly bool, sanitizeURL func(*zerolog.Logger, string) string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			start := time.Now()
+			err := next(ctx)
+			if err != nil {
+				ctx.Error(err)
+			}
+			stop := time.Now()
+			delta := stop.Sub(start)
+			code := ctx.Response().Status
+			method := ctx.Request().Method
+			if err != nil {
+				log.
+					Error().
+					Err(err).
+					Int("code", code).
+					Str("method", method).
+					Str("url", ctx.Request().URL.String()).
+					Str("ip_address", ctx.RealIP()).
+					Dur("request_duration", delta).
+					Msg("request failed")
+			} else if !errorsOnly {
+				log.
+					Info().
+					Int("code", code).
+					Str("method", method).
+					Str("url", ctx.Request().URL.String()).
+					Str("ip_address", ctx.RealIP()).
+					Dur("request_duration", delta).
+					Msg("request processed")
+			}
+			return err
+		}
+	}
+}
+
+// NewZeroLog creates a new zerolog logger
+func NewZeroLog(writer io.Writer) *zerolog.Logger {
+	zl := zerolog.New(writer).Output(zerolog.ConsoleWriter{Out: writer}).With().Timestamp().Logger()
+	return &zl
+}
+
+// ParseLevel parses a level from string to log level
+func ParseLevel(level string) zerolog.Level {
+	switch strings.ToUpper(level) {
+	case "FATAL":
+		return zerolog.FatalLevel
+	case "ERROR":
+		return zerolog.ErrorLevel
+	case "WARNING":
+		return zerolog.WarnLevel
+	case "INFO":
+		return zerolog.InfoLevel
+	case "DEBUG":
+		return zerolog.DebugLevel
+	default:
+		return zerolog.DebugLevel
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/rs/zerolog"
+)
+
+// ReverseProxy is a wrapper around httputil.ReverseProxy
+type ReverseProxy struct {
+	log *zerolog.Logger
+	p   *httputil.ReverseProxy
+}
+
+func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Gonvey", "Gonvey")
+	p.p.Transport = &Gonveyor{
+		log: p.log,
+	}
+	p.p.ServeHTTP(w, r)
+}

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Gonveyor is an HTTP transport layer in charge of the metrics and logging of requests
+// that are going through the proxy
+type Gonveyor struct {
+	log *zerolog.Logger
+}
+
+// RoundTrip is the method used by ServeHTTP to handle the incoming HTTP requests
+// We overload it to be able to add logging and metrics on both the request and the response
+func (g *Gonveyor) RoundTrip(request *http.Request) (*http.Response, error) {
+	start := time.Now()
+
+	response, err := http.DefaultTransport.RoundTrip(request)
+	if err != nil {
+		g.log.Error().Err(err).Msg("server not reachable")
+		return nil, err
+	}
+	elapsed := time.Since(start)
+
+	g.log.Info().
+		Str("client", request.RemoteAddr).
+		Str("request_addr", fmt.Sprint(request.URL)).
+		Int64("request_duration", elapsed.Nanoseconds()).
+		Int("status", response.StatusCode).
+		Msg("request proxied")
+
+	return response, err
+}


### PR DESCRIPTION
## Goal of this PR

This PR has been prioritized because it makes it easier later on to debug the project easily, and also provides value later on by allowing to customize the log level and to have the possibility to plug it to a log aggregator + log visualization software (such as ELK for example).

* Gives more information on the incoming / outgoing requests
  * Request duration
  * Client address
  * Response status code
* Makes it easier to differentiate normal behavior and errors thanks to the use of colors

Fixes #3 

## How to test it

Simply run `gonvey` and run a few curl queries to ensure that the logs are displayed properly like such:

<img width="960" alt="screenshot 2018-09-20 at 10 44 44" src="https://user-images.githubusercontent.com/6976628/45806993-b029b200-bcc2-11e8-98f7-83a53687c8a9.png">

Example of curl command: `curl -v http://0.0.0.0:8888/test`