### PR TITLE
Add CI (#9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+dist: trusty
+sudo: required
+language: go
+
+env:
+  - DEP_VERSION="0.5.0"
+
+services:
+  - docker
+
+before_install:
+  # Install docker
+  - sudo apt-get remove docker docker-engine docker.io
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo apt-get update
+  - sudo apt-get install -y docker-ce
+  - docker version
+  - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep
+  - chmod +x $GOPATH/bin/dep
+
+install:
+  - dep ensure
+  - docker build -t gonvey .
+
+notifications:
+  email:
+    recipients:
+      - brendan.le-glaunec@epitech.eu
+    on_success: never
+    on_failure: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/Ullaakut/gonvey
 
 RUN apk update && \
     apk upgrade && \
-    apk add curl
+    apk add curl git
 
 ENV DEP_VERSION="0.5.0"
 RUN curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Gonvey is a simple reverse proxy.
 
+[![Build Status](https://travis-ci.org/Ullaakut/gonvey.svg?branch=master)](https://travis-ci.org/Ullaakut/gonvey)
+
 ## Dependencies
 
 ### Docker build


### PR DESCRIPTION
## Goal of this PR

Adding CI early will ensure that I don't push something that doesn't build by accident later on, and make my development experience better overall.

For some reason Travis forces to run `go test` so we can't just build it in Docker, we need to install `dep` and run `dep ensure` in the travis script as well.

Fixes #9 

## How to test it

This branch should build successfully and get a tiny ✅

## Screenshots

<img width="1030" alt="screenshot 2018-09-20 at 12 56 18" src="https://user-images.githubusercontent.com/6976628/45814108-e112e280-bcd4-11e8-8d04-1c8852d99563.png">
