### PR TITLE
Add configuration with environment override (#4)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,52 @@
 
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
+  digest = "1:e1ff887e232b2d8f4f7c7db15a5fac7be418025afc4dda53c59c765dbb5aa6b4"
+  name = "github.com/go-playground/locales"
+  packages = [
+    ".",
+    "currency",
+  ]
+  pruneopts = "UT"
+  revision = "f63010822830b6fe52288ee52d5a1151088ce039"
+  version = "v0.12.1"
+
+[[projects]]
+  digest = "1:e022cf244bcac1b6ef933f1a2e0adcf6a6dfd7b872d8d41e4d4179bb09a87cbc"
+  name = "github.com/go-playground/universal-translator"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b32fa301c9fe55953584134cb6853a13c87ec0a1"
+  version = "v0.16.0"
+
+[[projects]]
+  digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
+  name = "github.com/hashicorp/hcl"
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token",
+  ]
+  pruneopts = "UT"
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:63801c64679bdeef1b63206f065d5a1f4c3a75ed66a3fbbd909bf98766542980"
   name = "github.com/labstack/echo"
   packages = ["."]
@@ -21,6 +67,14 @@
   version = "v0.2.7"
 
 [[projects]]
+  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
+
+[[projects]]
   digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
@@ -37,6 +91,22 @@
   version = "v0.0.4"
 
 [[projects]]
+  digest = "1:645110e089152bd0f4a011a2648fbb0e4df5977be73ca605781157ac297f50c4"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fa473d140ef3c6adf42d6b391fe76707f1f243c8"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
+
+[[projects]]
   digest = "1:5bc8f93f977b72a7a5264725c3bab275e69de0cc3e5c0dc1ee56feb564c33f03"
   name = "github.com/rs/zerolog"
   packages = [
@@ -47,6 +117,49 @@
   pruneopts = "UT"
   revision = "338f9bc14084d22cb8eeacd6492861f8449d715c"
   version = "v1.9.1"
+
+[[projects]]
+  digest = "1:6a4a11ba764a56d2758899ec6f3848d24698d48442ebce85ee7a3f63284526cd"
+  name = "github.com/spf13/afero"
+  packages = [
+    ".",
+    "mem",
+  ]
+  pruneopts = "UT"
+  revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
+  version = "v1.1.2"
+
+[[projects]]
+  digest = "1:516e71bed754268937f57d4ecb190e01958452336fa73dbac880894164e91c1f"
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8965335b8c7107321228e3e3702cab9832751bac"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:68ea4e23713989dc20b1bded5d9da2c5f9be14ff9885beef481848edd18c26cb"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "4a4406e478ca629068e7768fc33f3f044173c0a6"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:dab83a1bbc7ad3d7a6ba1a1cc1760f25ac38cdf7d96a5cdd55cd915a4f5ceaf9"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
+  version = "v1.0.2"
+
+[[projects]]
+  digest = "1:6e30a27eac59a148b3f7a32e0ba54706b31dcde5a42f63b22cb47873b62fa343"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8fb642006536c8d3760c99d4fa2389f5e2205631"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:c468422f334a6b46a19448ad59aaffdfc0a36b08fdcc1c749a0b29b6453d7e59"
@@ -84,6 +197,29 @@
   revision = "1561086e645b2809fb9f8a1e2a38160bf8d53bf4"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
+  name = "golang.org/x/text"
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm",
+  ]
+  pruneopts = "UT"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  digest = "1:e2f64cca6e235f32cd4c2f9be9ae0cda1f8608fc6fdb68936e8d10e4e0bb074d"
+  name = "gopkg.in/go-playground/validator.v9"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e69e9a28bb62b977fdc58d051f1bb477b7cbe486"
+  version = "v9.21.0"
+
+[[projects]]
   digest = "1:43b8a34f6390d8fbdcfd300ed52103064e9eaaecc7e50b7e3518fe246ebe8403"
   name = "gopkg.in/tylerb/graceful.v1"
   packages = ["."]
@@ -91,12 +227,22 @@
   revision = "4654dfbb6ad53cb5e27f37d99b02e16c1872fbbb"
   version = "v1.2.15"
 
+[[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/labstack/echo",
     "github.com/rs/zerolog",
+    "github.com/spf13/viper",
+    "gopkg.in/go-playground/validator.v9",
     "gopkg.in/tylerb/graceful.v1",
   ]
   solver-name = "gps-cdcl"

--- a/config.go
+++ b/config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/spf13/viper"
+	v "gopkg.in/go-playground/validator.v9"
+)
+
+// Config represents the Bloggo configuration
+type Config struct {
+	LogLevel   string `json:"log_level" validate:"required,eq=DEBUG|eq=INFO|eq=WARNING|eq=ERROR|eq=FATAL"`
+	ServerPort uint   `json:"server_port" validate:"required,min=1,max=65535"`
+	Endpoint   string `json:"endpoint"`
+}
+
+// Set default values for configuration parameters
+func init() {
+	viper.SetDefault("log_level", "DEBUG")
+	viper.SetDefault("server_port", 8888)
+	viper.SetDefault("endpoint", "http://0.0.0.0:4242")
+}
+
+// GetConfig sets the default values for the configuration and gets it from the environment/command line
+func GetConfig() (Config, error) {
+	var config Config
+
+	// Override default with environment variables
+	viper.SetEnvPrefix("GONVEY")
+	viper.AutomaticEnv()
+	viper.Unmarshal(&config)
+
+	config.LogLevel = viper.GetString("log_level")
+	config.ServerPort = uint(viper.GetInt("server_port"))
+	config.Endpoint = viper.GetString("endpoint")
+
+	validate := v.New()
+	err := validate.Struct(config)
+	if err != nil {
+		return config, err
+	}
+
+	return config, nil
+}
+
+// Print prints the current configuration
+func (c Config) Print(log *zerolog.Logger) {
+	log.Debug().
+		Str("log_level", c.LogLevel).
+		Str("endpoint", c.Endpoint).
+		Uint("server_port", c.ServerPort).
+		Msg("configuration")
+}


### PR DESCRIPTION
## Goal of this PR

This PR adds a simple configuration system using viper, that can be overridden though the environment and has default values.

For now this is still a single host reverse proxy so it's still simple, but it will become more complex once #2 is done, and will also have to work with a consul KV store in #6 

Fixes #4 

## How to test it

* `go run *.go`
* Ensure that the logs indicate that it uses the port `8888` and a log level of `DEBUG`, which is the default
* `export GONVEY_LOG_LEVEL=ERROR`
* `export GONVEY_SERVER_PORT=9034`
* Ensure that the logs indicate that it uses the port `9034` and a log level of `ERROR`, which is the default
* `export GONVEY_LOG_LEVEL=INVALIGLOGLEVEL`
* Ensure that the logs indicate a fatal error like such

<img width="962" alt="screenshot 2018-09-20 at 13 54 02" src="https://user-images.githubusercontent.com/6976628/45816670-a614ad00-bcdc-11e8-8dca-10a662287418.png">

## Screenshots

<img width="959" alt="screenshot 2018-09-20 at 13 50 14" src="https://user-images.githubusercontent.com/6976628/45816678-ad3bbb00-bcdc-11e8-80b4-581f8cecf82b.png">
