### PR TITLE
Gonvey can now map endpoints to paths - Multi host reverse proxy (#2)

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,8 +20,8 @@ func init() {
 	viper.SetDefault("log_level", "DEBUG")
 	viper.SetDefault("server_port", 8888)
 	viper.SetDefault("proxy_map", map[string][]string{
-		"/bloggo/": []string{"http://0.0.0.0:4242"},
-		"/test/":   []string{"http://0.0.0.0:4243", "http://0.0.0.0:4244", "http://0.0.0.0:4245"},
+		"/bloggo": []string{"http://0.0.0.0:4242"},
+		"/test":   []string{"http://0.0.0.0:4243", "http://0.0.0.0:4244", "http://0.0.0.0:4245"},
 	})
 }
 

--- a/config.go
+++ b/config.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 	v "gopkg.in/go-playground/validator.v9"
@@ -8,16 +10,19 @@ import (
 
 // Config represents the Bloggo configuration
 type Config struct {
-	LogLevel   string `json:"log_level" validate:"required,eq=DEBUG|eq=INFO|eq=WARNING|eq=ERROR|eq=FATAL"`
-	ServerPort uint   `json:"server_port" validate:"required,min=1,max=65535"`
-	Endpoint   string `json:"endpoint"`
+	LogLevel   string              `json:"log_level" validate:"required,eq=DEBUG|eq=INFO|eq=WARNING|eq=ERROR|eq=FATAL"`
+	ServerPort uint                `json:"server_port" validate:"required,min=1,max=65535"`
+	ProxyMap   map[string][]string `json:"proxy_map"`
 }
 
 // Set default values for configuration parameters
 func init() {
 	viper.SetDefault("log_level", "DEBUG")
 	viper.SetDefault("server_port", 8888)
-	viper.SetDefault("endpoint", "http://0.0.0.0:4242")
+	viper.SetDefault("proxy_map", map[string][]string{
+		"/bloggo/": []string{"http://0.0.0.0:4242"},
+		"/test/":   []string{"http://0.0.0.0:4243", "http://0.0.0.0:4244", "http://0.0.0.0:4245"},
+	})
 }
 
 // GetConfig sets the default values for the configuration and gets it from the environment/command line
@@ -31,7 +36,7 @@ func GetConfig() (Config, error) {
 
 	config.LogLevel = viper.GetString("log_level")
 	config.ServerPort = uint(viper.GetInt("server_port"))
-	config.Endpoint = viper.GetString("endpoint")
+	config.ProxyMap = viper.GetStringMapStringSlice("proxy_map")
 
 	validate := v.New()
 	err := validate.Struct(config)
@@ -46,7 +51,7 @@ func GetConfig() (Config, error) {
 func (c Config) Print(log *zerolog.Logger) {
 	log.Debug().
 		Str("log_level", c.LogLevel).
-		Str("endpoint", c.Endpoint).
+		Str("endpoint", fmt.Sprintf("%+v", c.ProxyMap)).
 		Uint("server_port", c.ServerPort).
 		Msg("configuration")
 }

--- a/proxy.go
+++ b/proxy.go
@@ -1,22 +1,101 @@
 package main
 
 import (
+	"io/ioutil"
+	"log"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 )
 
-// ReverseProxy is a wrapper around httputil.ReverseProxy
-type ReverseProxy struct {
-	log *zerolog.Logger
-	p   *httputil.ReverseProxy
+// loadBalance just randomly gets a proxy out of the slice of proxies
+// Not the smartest load balancing, but certainly the simplest
+func loadBalance(proxies []*httputil.ReverseProxy) *httputil.ReverseProxy {
+	if len(proxies) == 0 {
+		return nil
+	}
+
+	// set random seed
+	rand.Seed(time.Now().UnixNano())
+
+	return proxies[rand.Intn(len(proxies))]
 }
 
-func (p *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("X-Gonvey", "Gonvey")
-	p.p.Transport = &Gonveyor{
-		log: p.log,
+func splitPath(requestURI string) (string, string) {
+	if len(requestURI) < 1 {
+		return "", ""
 	}
-	p.p.ServeHTTP(w, r)
+
+	path := strings.TrimRightFunc(requestURI, func(r rune) bool {
+		return r != '/'
+	})
+
+	subpath := strings.TrimLeftFunc(requestURI[1:], func(r rune) bool {
+		return r != '/'
+	})
+
+	return path, subpath
+}
+
+// MultiHostReverseProxy is a wrapper around httputil.ReverseProxy
+type MultiHostReverseProxy struct {
+	log *zerolog.Logger
+	p   map[string][]*httputil.ReverseProxy
+}
+
+// NewMultiHostReverseProxy generates a new reverse proxy for multiple hosts from a proxy map
+func NewMultiHostReverseProxy(logger *zerolog.Logger, proxyMap map[string][]string) (*MultiHostReverseProxy, error) {
+	proxy := &MultiHostReverseProxy{
+		p:   make(map[string][]*httputil.ReverseProxy),
+		log: logger,
+	}
+
+	for path, endpoints := range proxyMap {
+		for _, endpoint := range endpoints {
+			url, err := url.Parse(endpoint)
+			if err != nil {
+				return nil, err
+			}
+
+			singleHostReverseProxy := httputil.NewSingleHostReverseProxy(url)
+
+			// disables logging on stderr if server is unreachable
+			singleHostReverseProxy.ErrorLog = log.New(ioutil.Discard, "", 0)
+
+			proxy.p[path] = append(proxy.p[path], singleHostReverseProxy)
+		}
+	}
+
+	return proxy, nil
+}
+
+func (mhrp *MultiHostReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Gonvey", "Gonvey")
+
+	// TODO: This only allows paths that are `/something/`, so for example you
+	// can't bind `/bloggo/api/v1/` to an endpoint and `/bloggo/api/v2` to another,
+	// as the split will just match with `/bloggo` for both
+	path, subpath := splitPath(r.RequestURI)
+
+	// Rewrite the URI to be forwarded by removing the path used for routing
+	// eg: `/bloggo/posts` becomes `/posts` redirected to an endpoint
+	// registered to the `/bloggo` route
+	r.URL.Path = subpath
+
+	// Pick a random endpoint for this path
+	proxy := loadBalance(mhrp.p[path])
+	if proxy == nil {
+		mhrp.log.Error().Str("path", path).Msg("unknown path")
+		w.WriteHeader(http.StatusNotFound)
+	} else {
+		proxy.Transport = &Gonveyor{
+			log: mhrp.log,
+		}
+		proxy.ServeHTTP(w, r)
+	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -31,9 +31,8 @@ func splitPath(requestURI string) (string, string) {
 		return "", ""
 	}
 
-	path := strings.TrimRightFunc(requestURI, func(r rune) bool {
-		return r != '/'
-	})
+	pathIdx := strings.Index(requestURI[1:], "/")
+	path := requestURI[:pathIdx+1]
 
 	subpath := strings.TrimLeftFunc(requestURI[1:], func(r rune) bool {
 		return r != '/'

--- a/transport.go
+++ b/transport.go
@@ -21,7 +21,12 @@ func (g *Gonveyor) RoundTrip(request *http.Request) (*http.Response, error) {
 
 	response, err := http.DefaultTransport.RoundTrip(request)
 	if err != nil {
-		g.log.Error().Err(err).Msg("server not reachable")
+		g.log.Error().
+			Err(err).
+			Str("client", request.RemoteAddr).
+			Str("endpoint", fmt.Sprint(request.Host)).
+			Str("path", request.RequestURI).
+			Msg("endpoint not reachable")
 		return nil, err
 	}
 	elapsed := time.Since(start)

--- a/transport.go
+++ b/transport.go
@@ -24,7 +24,6 @@ func (g *Gonveyor) RoundTrip(request *http.Request) (*http.Response, error) {
 		g.log.Error().
 			Err(err).
 			Str("client", request.RemoteAddr).
-			Str("endpoint", fmt.Sprint(request.Host)).
 			Str("path", request.RequestURI).
 			Msg("endpoint not reachable")
 		return nil, err


### PR DESCRIPTION
## Goal of this PR

This PR changes the endpoint configuration to become a proxy map.

Basically, you can now match multiple endpoints to a path like such:

<img width="678" alt="screenshot 2018-09-20 at 17 39 10" src="https://user-images.githubusercontent.com/6976628/45829876-28f93000-bcfc-11e8-8627-f7e4ba32e61f.png">

If one path has multiple endpoints, Gonvey will load balance requests on this path to these endpoints. The load balancing is done by randomly distributing incoming requests among endpoints.

The next step is to make it possible to add/remove/edit endpoints without restarting the proxy! That's what will be done in issue #6 🎉 

Fixes #2 

## How to test it

* Modify `config.go` to try out different proxy maps
* Run `go run *.go` to run `Gonvey`
* Using curl, make requests on the paths that you bound in the config, and see if they are being properly load balanced between set endpoints
* Ensure that when an unbound path is given in a request, Gonvey responds with a 404 and logs 
<img width="492" alt="screenshot 2018-09-20 at 17 39 23" src="https://user-images.githubusercontent.com/6976628/45829864-226ab880-bcfc-11e8-891e-44cc8d87bea1.png">

## Screenshots

<img width="962" alt="screenshot 2018-09-20 at 17 29 21" src="https://user-images.githubusercontent.com/6976628/45829932-4a5a1c00-bcfc-11e8-9d27-6ec55de6643b.png">
